### PR TITLE
feat: deeplink to trigger workflow replay from workflowId query

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -3,7 +3,7 @@ import {
   type InjectingCheckMessage,
   type RecordingCheckMessage,
   type ReplayCheckMessage,
-  type DeepLinkWorkflowMessage,
+  type ReplayDeepLinkWorkflowMessage,
   Event,
   sendExt,
   sendTab,
@@ -28,7 +28,7 @@ type ContentScript = {
     | InjectingCheckMessage
     | RecordingCheckMessage
     | ReplayCheckMessage
-    | DeepLinkWorkflowMessage
+    | ReplayDeepLinkWorkflowMessage
 }
 
 const CONTENT_SCRIPTS: ContentScript[] = [

--- a/utils/messages.ts
+++ b/utils/messages.ts
@@ -107,7 +107,7 @@ export type ReplayRecordingKeyupMessage = BaseMessage<
   { selector: Selector; value: string; timeoutMillis: number }
 >
 
-export type DeepLinkWorkflowMessage = BaseMessage<
+export type ReplayDeepLinkWorkflowMessage = BaseMessage<
   Event.DEEPLINK_WORKFLOW,
   { workflowId: string }
 >
@@ -134,7 +134,7 @@ export type Message =
   | ReplayInjectingMessage
   | ReplayRecordingClickMessage
   | ReplayRecordingKeyupMessage
-  | DeepLinkWorkflowMessage
+  | ReplayDeepLinkWorkflowMessage
 
 export type Response<M extends Message> = M extends
   | ExtractingQueryMessage
@@ -147,10 +147,9 @@ export type Response<M extends Message> = M extends
           | ReplayInjectingMessage
           | ReplayRecordingClickMessage
           | ReplayRecordingKeyupMessage
+          | ReplayDeepLinkWorkflowMessage
       ? TaskResult
-      : M extends DeepLinkWorkflowMessage
-        ? null
-        : null
+      : null
 
 export const sendExt = <M extends Message>(
   message: M,


### PR DESCRIPTION
- Deeplink into the chrome plugin with a `workflowId`
- Query the WorkflowData (init and steps) from this id to use as Workflow to execute
- Execute workflow through Playwright Chromium Fluidic extension: https://github.com/FluidicML/flow-minder-ts/pull/11