### PR TITLE
Rename "Prompt" to "Input".

### DIFF
--- a/entrypoints/sidepanel/RunnerTab.tsx
+++ b/entrypoints/sidepanel/RunnerTab.tsx
@@ -247,7 +247,7 @@ const runTask = async (context: Context): Promise<TaskResult> => {
       result = await runOpenAITask(context, step.values)
       break
     }
-    case StepKind.PROMPT: {
+    case StepKind.INPUT: {
       result = { status: TaskStatus.SUCCEEDED, isPaused: true }
       break
     }

--- a/entrypoints/sidepanel/builder_tab/StepInjectingForm.tsx
+++ b/entrypoints/sidepanel/builder_tab/StepInjectingForm.tsx
@@ -250,8 +250,8 @@ const StepInjectingForm = ({
   if (params.size === 0) {
     return (
       <p>
-        You have not defined any parameters yet. Consider using a{" "}
-        <span className="font-bold">Prompt</span> step before this one.
+        You have not defined any parameters yet. Consider using an{" "}
+        <span className="font-bold">Input</span> step before this one.
       </p>
     )
   }

--- a/entrypoints/sidepanel/builder_tab/StepInputForm.tsx
+++ b/entrypoints/sidepanel/builder_tab/StepInputForm.tsx
@@ -5,10 +5,10 @@ import { Control, useFieldArray, useForm } from "react-hook-form"
 import PlusIcon from "@/components/icons/Plus"
 import TrashIcon from "@/components/icons/Trash"
 import {
-  type StepPromptSchema,
+  type StepInputSchema,
   type Step,
   StepKind,
-  stepPromptSchema,
+  stepInputSchema,
 } from "@/utils/schema"
 import {
   Form,
@@ -22,7 +22,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
 type ParameterFieldProps = {
-  control: Control<StepPromptSchema>
+  control: Control<StepInputSchema>
   index: number
   onRemove: () => void
 }
@@ -55,14 +55,14 @@ const ParameterField = ({ control, index, onRemove }: ParameterFieldProps) => {
   )
 }
 
-type StepPromptFormProps = {
-  defaultValues: StepPromptSchema | null
+type StepInputFormProps = {
+  defaultValues: StepInputSchema | null
   onChange: (values: Step | null) => void
 }
 
-const StepPromptForm = ({ defaultValues, onChange }: StepPromptFormProps) => {
-  const form = useForm<StepPromptSchema>({
-    resolver: zodResolver(stepPromptSchema),
+const StepInputForm = ({ defaultValues, onChange }: StepInputFormProps) => {
+  const form = useForm<StepInputSchema>({
+    resolver: zodResolver(stepInputSchema),
     defaultValues: defaultValues ?? { params: [{ name: "" }] },
   })
   const params = useFieldArray({
@@ -72,9 +72,9 @@ const StepPromptForm = ({ defaultValues, onChange }: StepPromptFormProps) => {
 
   React.useEffect(() => {
     const subscription = form.watch((values) => {
-      const parsed = stepPromptSchema.safeParse(values)
+      const parsed = stepInputSchema.safeParse(values)
       onChange(
-        parsed.success ? { kind: StepKind.PROMPT, values: parsed.data } : null
+        parsed.success ? { kind: StepKind.INPUT, values: parsed.data } : null
       )
     })
     return () => subscription.unsubscribe()
@@ -109,6 +109,6 @@ const StepPromptForm = ({ defaultValues, onChange }: StepPromptFormProps) => {
     </Form>
   )
 }
-StepPromptForm.displayName = "StepPromptForm"
+StepInputForm.displayName = "StepInputForm"
 
-export default StepPromptForm
+export default StepInputForm

--- a/entrypoints/sidepanel/builder_tab/StepTabPanel.tsx
+++ b/entrypoints/sidepanel/builder_tab/StepTabPanel.tsx
@@ -17,9 +17,9 @@ import BracesIcon from "@/components/icons/Braces"
 import TrashIcon from "@/components/icons/Trash"
 import StepExtractingForm from "./StepExtractingForm"
 import StepInjectingForm from "./StepInjectingForm"
+import StepInputForm from "./StepInputForm"
 import StepNavigateForm from "./StepNavigateForm"
 import StepOpenAIForm from "./StepOpenAIForm"
-import StepPromptForm from "./StepPromptForm"
 import StepRecordingForm from "./StepRecordingForm"
 
 type ParameterSheetProps = {
@@ -128,11 +128,11 @@ const StepTabPanel = React.forwardRef<
           />
         )
       }
-      case StepKind.PROMPT: {
+      case StepKind.INPUT: {
         return (
-          <StepPromptForm
+          <StepInputForm
             defaultValues={
-              defaultValues?.kind === StepKind.PROMPT
+              defaultValues?.kind === StepKind.INPUT
                 ? defaultValues.values
                 : null
             }

--- a/entrypoints/sidepanel/runner_tab/StepInputContent.tsx
+++ b/entrypoints/sidepanel/runner_tab/StepInputContent.tsx
@@ -16,7 +16,7 @@ import {
 import { useSharedStore } from "../store"
 import { type StepContentProps } from "./StepContent"
 
-const stepPromptContentSchema = z.object({
+const stepInputContentSchema = z.object({
   params: z
     .array(
       z.object({
@@ -31,10 +31,10 @@ const stepPromptContentSchema = z.object({
     .nonempty(),
 })
 
-type StepPromptContentSchema = z.infer<typeof stepPromptContentSchema>
+type StepInputContentSchema = z.infer<typeof stepInputContentSchema>
 
 type ParameterFieldProps = {
-  control: Control<StepPromptContentSchema>
+  control: Control<StepInputContentSchema>
   label: string
   index: number
 }
@@ -64,15 +64,15 @@ const ParameterField = ({ control, label, index }: ParameterFieldProps) => {
   )
 }
 
-const StepPromptContent = ({
+const StepInputContent = ({
   values,
   result,
-}: StepContentProps<StepPromptSchema>) => {
+}: StepContentProps<StepInputSchema>) => {
   const store = useSharedStore()
   const latest = result?.results[result.results.length - 1] ?? null
 
-  const form = useForm<StepPromptContentSchema>({
-    resolver: zodResolver(stepPromptContentSchema),
+  const form = useForm<StepInputContentSchema>({
+    resolver: zodResolver(stepInputContentSchema),
     defaultValues: {
       params: values.params.map((p) => ({ name: p.name, value: "" })),
     },
@@ -83,7 +83,7 @@ const StepPromptContent = ({
     name: "params",
   })
 
-  const onSubmit: SubmitHandler<StepPromptContentSchema> = (values) => {
+  const onSubmit: SubmitHandler<StepInputContentSchema> = (values) => {
     if (store.runnerActive === null) {
       return
     }
@@ -126,6 +126,6 @@ const StepPromptContent = ({
 
   return <span>{latest.message ?? "Finished prompting."}</span>
 }
-StepPromptContent.displayName = "StepPromptContent"
+StepInputContent.displayName = "StepInputContent"
 
-export default StepPromptContent
+export default StepInputContent

--- a/entrypoints/sidepanel/runner_tab/StepResultCard.tsx
+++ b/entrypoints/sidepanel/runner_tab/StepResultCard.tsx
@@ -13,9 +13,9 @@ import {
 import { type StepResult, getStepResultStatus } from "@/utils/workflow"
 import StepExtractingContent from "./StepExtractingContent"
 import StepInjectingContent from "./StepInjectingContent"
+import StepInputContent from "./StepInputContent"
 import StepNavigateContent from "./StepNavigateContent"
 import StepOpenAIContent from "./StepOpenAIContent"
-import StepPromptContent from "./StepPromptContent"
 import StepRecordingContent from "./StepRecordingContent"
 
 type StepCardContentProps = {
@@ -39,8 +39,8 @@ const StepCardContent = ({ step, result }: StepCardContentProps) => {
     case StepKind.OPENAI: {
       return <StepOpenAIContent values={step.values} result={result} />
     }
-    case StepKind.PROMPT: {
-      return <StepPromptContent values={step.values} result={result} />
+    case StepKind.INPUT: {
+      return <StepInputContent values={step.values} result={result} />
     }
     case StepKind.RECORDING: {
       return <StepRecordingContent values={step.values} result={result} />

--- a/entrypoints/sidepanel/store/runner_slice.ts
+++ b/entrypoints/sidepanel/store/runner_slice.ts
@@ -164,7 +164,7 @@ export const runnerSlice: SharedStateCreator<RunnerSlice> = (set, get) => ({
           taskIndex = 0
           break
         }
-        case StepKind.PROMPT: {
+        case StepKind.INPUT: {
           stepIndex += 1
           taskIndex = 0
           break


### PR DESCRIPTION
"Input" is the term used by copy.ai. How do we feel about that? I'm open to other suggestions though I feel "Context" (as suggested in https://github.com/FluidicML/fluidic-workflows/issues/31) might also be really confusing.

Fixes https://github.com/FluidicML/fluidic-workflows/issues/31